### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/support": ">=5.4",
-        "illuminate/http": ">=5.4",
+        "illuminate/support": "5.4.* || 5.5.*",
+        "illuminate/http": "5.4.* || 5.5.*",
         "intervention/image": "^2.4"
     },
     "require-dev": {


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x`, `5.*` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.